### PR TITLE
Fixed highlightjs URL for hosting secured documentation

### DIFF
--- a/default.twig
+++ b/default.twig
@@ -66,7 +66,7 @@
 
         <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
         <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
-        <script src="http://yandex.st/highlightjs/7.5/highlight.min.js"></script>
+        <script src="//yandex.st/highlightjs/7.5/highlight.min.js"></script>
 
         <script>
             $(function() {


### PR DESCRIPTION
HTTP url doesn't allow to recover highlight.min.js when hosting documentation on a secured server.