### PR TITLE
Added word-wrapping to code blocks

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -92,4 +92,6 @@ code {
     color: #c5c8c6;
     border: solid 1px #3D5166;
     background-color: #1D2B3A;
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -94,4 +94,5 @@ code {
     background-color: #1D2B3A;
     white-space: pre-wrap;
     white-space: -moz-pre-wrap;
+    word-wrap: break-word;
 }


### PR DESCRIPTION
Fixed a small bug where the <code> blocks not rendered properly. Added `white-space: pre-wrap` to all code block to allow word wrapping.

In example: http://prntscr.com/9o9u3d
Result: http://prntscr.com/9o9vd3